### PR TITLE
Fixing the code sections in Beginning with Octopress 

### DIFF
--- a/guides/octopress-for-beginners.md
+++ b/guides/octopress-for-beginners.md
@@ -27,15 +27,26 @@ With [Koding](https://koding.com) this is not the issue. Koding enables the "loc
 
 1.) First, we want to get ahold of the Octopress code base. Open your [Terminal](https://koding.com/Develop/Terminal) and run the following two commands to clone Octopress, and navigate into the directory.
 
-[code] git clone git://github.com/imathis/octopress.git octopress cd octopress [/code]
+```
+git clone git://github.com/imathis/octopress.git octopress 
+cd octopress
+```
 
 2.) Next, we need to install some dependencies for Octopress. Run the following commands, which will install Bundle, then use Bundle to install the Octopress dependencies. Lastly, we use `rake` to set up some directories and initialize our project.
 
-[code] sudo gem install bundle bundle install rake install [/code]
+```
+sudo gem install bundle
+bundle install
+rake install
+```
 
 3.) That's it for Octopress! But how do we view it? To view it, we need to compile the html and expose that to Apache _(our web server)_. To do this, run the following commands which will generate the html, then symlink our compiled directory as our main Web directory.
 
-[code] rake generate mv ~/Web ~/Web.bkp ln -s ~/octopress/public ~/Web [/code]
+```
+rake generate 
+mv ~/Web ~/Web.bkp 
+ln -s ~/octopress/public ~/Web
+```
 
 4.) Now open up `http://username.kd.io` and view your hard work!
 


### PR DESCRIPTION
Using triple backticks for code section in "Beginning with Octopress" page to be consistent with other code sections.
