### PR TITLE
Update index.md

### DIFF
--- a/guides/installing-wordpress/index.md
+++ b/guides/installing-wordpress/index.md
@@ -108,6 +108,9 @@ define('DB_USER', 'username');
 
 /** MySQL database password */
 define('DB_PASSWORD', 'password');
+
+define('FS_METHOD', 'direct');
+/* That's all, stop editing! Happy blogging. */
 ```
 
 The above variables: *database_name*, *username*, *password* should be replaced with the values you set when creating the database on [Step 1](#step-1).
@@ -124,6 +127,11 @@ mkdir wp-content/uploads
 
 ```
 sudo chown -R :www-data wp-content/uploads
+```
+
+*Setting the permission of the wp-config.php to 777
+```
+chmod -R 777 /wordpress/wp-config.php
 ```
 
 ## Step 5 - Finalizing the Wordpress install


### PR DESCRIPTION
Adding this line "define('FS_METHOD', 'direct');" in the wp-config.php file allows the user to install or upload images, themes, plugins, etc. The purpose of the change is that whenever the user tries to upload some file it asks for the FTP Credentials and when given it stops responding. Defining the "direct" method and setting the permission of the wp-config.php file to 777 solves the problem and the user is now allowed to upload to wordpress.
