### PR TITLE
Made links more noticeable

### DIFF
--- a/.metalsmith/sass/main.scss
+++ b/.metalsmith/sass/main.scss
@@ -18,7 +18,7 @@ $color_0: #2c3134;
 $color_1: #b3b3b3;
 $color_2: #858585;
 $color_3: #c5c5c5;
-$color_4: #838485;
+$color_4: #00B820;
 $color_5: #525658;
 
 $white:         #fff;


### PR DESCRIPTION
Links in guides aren't that noticeable; if you're **looking** for links, you might catch them. Changing the color to something of this sort this would help. I chose a shade of green since greens seems to the secondary color of Koding's theme.
